### PR TITLE
Fix spelling and some clippy lints

### DIFF
--- a/src/widget/chart.rs
+++ b/src/widget/chart.rs
@@ -1,14 +1,14 @@
 pub struct Chart {
     cols: i32,
     rows: i32,
-    show_pourcent: bool
+    show_percent: bool
 }
 
 impl Chart {
-    pub fn display(&self, pourcents: &Vec<i32>) -> String {
-        let mut data = pourcents.to_vec();
-        if pourcents.len() >= ((self.cols * 2) - 1) as usize {
-            data = pourcents.as_slice()[pourcents.len() + 2 - (self.cols * 2) as usize..].to_vec();
+    pub fn display(&self, percents: &Vec<i32>) -> String {
+        let mut data = percents.to_vec();
+        if percents.len() >= ((self.cols * 2) - 1) as usize {
+            data = percents.as_slice()[percents.len() + 2 - (self.cols * 2) as usize..].to_vec();
         }
         data.reverse();
 
@@ -54,27 +54,27 @@ impl Chart {
         let mut graph: String = "".to_string();
 
         let mut graph_rows = self.rows;
-        if self.show_pourcent {
+        if self.show_percent {
             graph_rows = self.rows - 1;
         }
 
         for row in 0..graph_rows {
             let mut i = 0;
             while i < data.len() {
-                let pourcent_one = data[i as usize];
-                let mut tmp_one = pourcent_one as f32 / 100. * self.rows as f32 * 4.;
+                let percent_one = data[i as usize];
+                let mut tmp_one = percent_one as f32 / 100. * self.rows as f32 * 4.;
                 if tmp_one < 1. {
                     tmp_one = 1.;
                 }
                 let mut full_block_to_add_one = tmp_one as i32 - (4 * row);
 
-                let mut pourcent_two = 0;
-                let mut tmp_two = pourcent_two as f32 / 100. * self.rows as f32 * 4.;
+                let mut percent_two = 0;
+                let mut tmp_two = percent_two as f32 / 100. * self.rows as f32 * 4.;
                 let mut full_block_to_add_two = tmp_two as i32 - (4 * row);
 
                 if i as usize + 1 < data.len() {    
-                    pourcent_two = data[i as usize + 1];
-                    tmp_two = pourcent_two as f32 / 100. * self.rows as f32 * 4.;
+                    percent_two = data[i as usize + 1];
+                    tmp_two = percent_two as f32 / 100. * self.rows as f32 * 4.;
                     if tmp_two < 1. {
                         tmp_two = 1.;
                     }
@@ -102,15 +102,15 @@ impl Chart {
             graph = format!("\n{}{}", graph, " ".repeat(space_to_add as usize));
         }
 
-        if self.show_pourcent && data.len() != 0 {
+        if self.show_percent && !data.is_empty() {
             graph = format!("{}%{}{}", graph, data[0].to_string().chars().rev().collect::<String>()," ".repeat((self.cols - data[0].to_string().chars().count() as i32 - 2) as usize));
         }
 
         graph.chars().rev().collect::<String>()
     }
 
-    pub fn new(cols: i32, rows: i32, show_pourcent: bool) -> Chart {
-        Chart{cols: cols, rows: rows, show_pourcent: show_pourcent}
+    pub fn new(cols: i32, rows: i32, show_percent: bool) -> Chart {
+        Chart{cols, rows, show_percent}
     }
 
     pub fn resize(&mut self, cols: i32, rows: i32) {

--- a/src/widget/listview.rs
+++ b/src/widget/listview.rs
@@ -11,8 +11,8 @@ pub struct ListView {
 }
 
 impl ListView {
-    pub fn new(height: i32, width: i32, items: &Vec<ListItem>, primary_key: &str, secondary_keys: Vec<String>) -> ListView {
-        ListView{height: height, width: width, counter: 0, items: items.to_vec(), primary_key: primary_key.to_string(), secondary_keys: secondary_keys, selected_line: 1, start_index: 0, sort_key: primary_key.to_string()}
+    pub fn new(height: i32, width: i32, items: &[ListItem], primary_key: &str, secondary_keys: Vec<String>) -> ListView {
+        ListView{height, width, counter: 0, items: items.to_vec(), primary_key: primary_key.to_string(), secondary_keys, selected_line: 1, start_index: 0, sort_key: primary_key.to_string()}
     }
 
     pub fn previous(&mut self) {
@@ -97,7 +97,7 @@ impl ListView {
         }
     }
 
-    pub fn update_items(&mut self, items: &Vec<ListItem>) {
+    pub fn update_items(&mut self, items: &[ListItem]) {
         self.items = items.to_vec();
         if items.len() < self.counter as usize {
             self.counter = items.len() as i32 - 1;

--- a/src/window.rs
+++ b/src/window.rs
@@ -16,11 +16,11 @@ impl Window {
     pub fn new(height: i32, width: i32, x: i32, y: i32, border_color: attr_t, text_color: attr_t, title: String) -> Window {
         let win_box = newwin(height, width, y, x);
         let win_inner = derwin(win_box, height - 2, width - 2, 1, 1);
-        let new_win = Window{height: height, width: width, x: x, y: y, curse_window: win_box, inner_window: win_inner, text_color: text_color, title: title, border_color: border_color};
+        let new_win = Window{height, width, x, y, curse_window: win_box, inner_window: win_inner, text_color, title, border_color};
         wattrset(new_win.inner_window, text_color);
         new_win.draw_border();
         wrefresh(new_win.curse_window);
-        return new_win;
+        new_win
     }
 
     pub fn refresh(&self) {


### PR DESCRIPTION
Fix spelling in src/widget/chart.rs:

from pourcent to percent

Fix some easy Clippy lints:

https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
https://rust-lang.github.io/rust-clippy/master/index.html#needless_return